### PR TITLE
Add KubeCon NA 2025 Platform Engineering Talk

### DIFF
--- a/c/_talks/2025-11-11-kubecon-platform-engineering.md
+++ b/c/_talks/2025-11-11-kubecon-platform-engineering.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "Platform Engineering: Day Zero, The Origin Story"
+description: >
+  Getting Started with Platform Engineering - KubeCon NA 2025
+---
+
+How do you get started with platform engineering if you don't have time and resources to build a platform?
+
+# Recap
+<a href="https://kccncna2025.sched.com/event/27FV1/platform-engineering-day-zero-the-origin-story-murriel-mccabe-google?iframe=no" target="_blank">KubeCon + CloudNativeCon North America 2025 Event Page</a>
+
+In this talk, I discuss how to bootstrap platform engineering when you're starting from a place of high technical debt and limited resources. We move away from the "ideal" greenfield scenario and focus on practical, incremental steps to build a roadmap from your current reality.
+
+Key takeaways:
+* **Roadmap Development:** How to build a platform engineering roadmap starting from your current state, no matter how "messy" it is.
+* **Tooling & Tech:** An exploration of common tools and technologies used in building internal developer platforms.
+* **Cultural Shift:** Approaches for championing a platform engineering mindset within your organization.
+* **Iterative Improvement:** Focusing on continuous, small improvements to teams, processes, and technologies.
+
+# Video
+<a href="https://www.youtube.com/watch?v=dIgxuxdDYCs" target="_blank">Watch the talk on YouTube</a>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dIgxuxdDYCs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
I've added the new talk page for "Platform Engineering: Day Zero, The Origin Story" from KubeCon NA 2025. 

The new file is located at `c/_talks/2025-11-11-kubecon-platform-engineering.md`. It includes:
- The requested title and description in the YAML front matter.
- A Recap section with a link to the KubeCon event page and a summary of key points from the talk.
- A Video section featuring both a direct link to the YouTube video and an embedded player for easy viewing.

As per your request, I've skipped the slides section for now. 


---
*PR created automatically by Jules for task [9981602336889937153](https://jules.google.com/task/9981602336889937153) started by @murriel*